### PR TITLE
Fix #224: expertise pages link to club's on-site page

### DIFF
--- a/Photo Club Hub HTML/Ignite/Level 0/ExpertisePage.swift
+++ b/Photo Club Hub HTML/Ignite/Level 0/ExpertisePage.swift
@@ -31,7 +31,7 @@ struct ExpertisePage: StaticPage {
     private struct MembershipCell {
         let roleDescriptionOfClubTown: String // e.g. "Member of Fotoclub Klik, Eindhoven"
         let portfolioURL: URL? // links to portfolio on clubs own site
-        let clubPageURL: URL? // links to the club's membership list page on this site
+        let clubPagePath: String // on-site path to the club's membership list page, e.g. "/nl/clubs/fgDeGender"
         let thumbnailSrc: String // either "/images/foo.jpg" (local) or "https://..." (remote)
     }
 
@@ -93,7 +93,8 @@ struct ExpertisePage: StaticPage {
                         roleDescriptionOfClubTown: membership.roleDescriptionOfClubTown(
                             languageBundle: Bundle.photoClubHubDataModuleForLanguage(language)),
                         portfolioURL: membership.level3URL_,
-                        clubPageURL: membership.organization.level2URLDir,
+                        clubPagePath: "/" + Members.relativePath(languageID: language,
+                                                                 clubNickname: membership.organization.nickName),
                         thumbnailSrc: thumbnailSrc
                     )
                 }
@@ -220,9 +221,7 @@ struct ExpertisePage: StaticPage {
                 .padding(0)
                 .cursor(.pointer)
                 .onClick {
-                    if let clubPageURL = cell.clubPageURL {
-                        CustomAction("window.location.href=\"\(clubPageURL)\";")
-                    }
+                    CustomAction("window.location.href=\"\(cell.clubPagePath)\";")
                 }
         }
         .style("width: \(cellWidth)px", "text-align: center", "flex-shrink: 0",


### PR DESCRIPTION
## Summary
Fixes #224. On expertise pages (e.g. `/nl/expertises/Architecture`), each member thumbnail caption linked to the club's **external website** (via `level2URLDir`, e.g. `www.fcDeGender.nl/...`) instead of the club's membership page **on this site**.

## Change
In `ExpertisePage.swift`:
- `MembershipCell.clubPageURL: URL?` → `clubPagePath: String`.
- The path is now built with `Members.relativePath(languageID:clubNickname:)`, matching the convention already used by `OrganizationsPage`. This respects the page's language (e.g. `/nl/clubs/fgDeGender` on the Dutch page, `/en/clubs/fgDeGender` on the English page).
- The caption `onClick` navigates to that path; the now-always-present value lets the old `if let` guard go.

The thumbnail image still links to the photographer's external portfolio (unchanged) — only the caption link was wrong.

## Testing
- `BuildProject` succeeds with no errors or warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)