### PR TITLE
Fix Level 0/2 reader test crashes: resource bundle resolution + per-test isolation

### DIFF
--- a/Photo Club Hub Data/Sources/Photo Club Hub Data/ViewModel/ListReaders/FetchAndProcessFile.swift
+++ b/Photo Club Hub Data/Sources/Photo Club Hub Data/ViewModel/ListReaders/FetchAndProcessFile.swift
@@ -105,13 +105,20 @@ struct FetchAndProcessFile {
             return url // Search oder #1
         }
 
-        let searchDirs = ([Bundle.main.resourceURL, // "../Build/Products/Debug/Photo%20Club%20Hub%20HTML.app"
-                           Bundle.main.bundleURL.deletingLastPathComponent()] // ..Build/Products/Debug"
-                          // Also scan any loaded code bundle: when unit tests run under the standalone
-                          // `xctest` tool, Bundle.main is that tool, so the test resources live in the
-                          // `.xctest` bundle's nested `<Package>_<Target>.bundle` instead.
-                          + Bundle.allBundles.map { $0.resourceURL })
+        // When unit tests run under the standalone `xctest` tool, Bundle.main is that tool, so the test
+        // resources live in the loaded `.xctest` bundle's nested `<Package>_<Target>.bundle` instead.
+        // Reach it via the `.xctest` bundle (a build product in DerivedData) rather than Bundle.allBundles
+        // as a whole: allBundles also lists frameworks packaged inside Xcode.app, and enumerating the
+        // resource bundles it lists trips the macOS privacy (TCC) "would like to access data from other apps" prompt.
+        var searchDirs = [Bundle.main.resourceURL, // "../Build/Products/Debug/Photo%20Club%20Hub%20HTML.app"
+                          Bundle.main.bundleURL.deletingLastPathComponent()] // ..Build/Products/Debug"
                          .compactMap { $0 }
+        for testBundle in Bundle.allBundles where testBundle.bundleURL.pathExtension == "xctest" {
+            if let resourceURL = testBundle.resourceURL {
+                searchDirs.append(resourceURL) // holds the nested <Package>_<Target>.bundle
+            }
+            searchDirs.append(testBundle.bundleURL.deletingLastPathComponent()) // sibling standalone bundle
+        }
         for dir in searchDirs {
             guard let entries = try? FileManager.default.contentsOfDirectory( at: dir,
                                                                               includingPropertiesForKeys: nil)

--- a/Photo Club Hub Data/Sources/Photo Club Hub Data/ViewModel/ListReaders/FetchAndProcessFile.swift
+++ b/Photo Club Hub Data/Sources/Photo Club Hub Data/ViewModel/ListReaders/FetchAndProcessFile.swift
@@ -105,9 +105,13 @@ struct FetchAndProcessFile {
             return url // Search oder #1
         }
 
-        let searchDirs = [Bundle.main.resourceURL, // "../Build/Products/Debug/Photo%20Club%20Hub%20HTML.app"
-                          Bundle.main.bundleURL.deletingLastPathComponent()]
-                         .compactMap { $0 } // ..Build/Products/Debug"
+        let searchDirs = ([Bundle.main.resourceURL, // "../Build/Products/Debug/Photo%20Club%20Hub%20HTML.app"
+                           Bundle.main.bundleURL.deletingLastPathComponent()] // ..Build/Products/Debug"
+                          // Also scan any loaded code bundle: when unit tests run under the standalone
+                          // `xctest` tool, Bundle.main is that tool, so the test resources live in the
+                          // `.xctest` bundle's nested `<Package>_<Target>.bundle` instead.
+                          + Bundle.allBundles.map { $0.resourceURL })
+                         .compactMap { $0 }
         for dir in searchDirs {
             guard let entries = try? FileManager.default.contentsOfDirectory( at: dir,
                                                                               includingPropertiesForKeys: nil)

--- a/Photo Club Hub Data/Tests/Photo Club Hub DataTests/Level0JsonReaderTest.swift
+++ b/Photo Club Hub Data/Tests/Photo Club Hub DataTests/Level0JsonReaderTest.swift
@@ -13,21 +13,35 @@ private let isBeingTested = true
 
 @MainActor @Suite("Tests the Level 0 JSON reader") struct Level0JsonReaderTests {
 
-    private let context: NSManagedObjectContext
+    private let testPersistenceController: PersistenceController
+    private let viewContext: NSManagedObjectContext
 
     init () {
-        context = PersistenceController.shared.container.viewContext
+        // Each test gets its own private in-memory store, so the app's concurrent background
+        // data-loading into PersistenceController.shared can't pollute the Expertise/PhotographerExpertise
+        // counts below. Swift Testing creates a fresh suite instance (and thus a fresh init) per test, so
+        // the store is effectively per-test — no deletion or cross-test isolation needed.
+        testPersistenceController = PersistenceController(inMemory: true)
+        viewContext = testPersistenceController.container.viewContext
+        viewContext.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
+
+        // The empty store lacks the constant records the app seeds at launch; seed them here.
+        // Must run on the main-queue viewContext (initConstants does a bare save()). See #749.
+        Language.initConstants(context: viewContext)
+        OrganizationType.initConstants(context: viewContext)
     }
 
     // Read root.level0.json and check for parsing errors.
     // Clears all CoreData expertises. Runs on background thread, adding bunch of extra complexity ;-(
     @Test("Parse empty.level0.json") func emptyLevel0Parse() async {
-        let bgContext = PersistenceController.shared.container.newBackgroundContext()
+        let bgContext = testPersistenceController.container.newBackgroundContext()
         bgContext.name = "EmptyLevel0"
         bgContext.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
         bgContext.automaticallyMergesChangesFromParent = true
 
-        Model.deleteCoreDataObjects(viewContext: bgContext, deletionScope: .expertisesOnly)
+        // Deletion must run on the main-queue viewContext: deleteCoreDataObjects is a @MainActor
+        // main-thread API (its bare save() would trip _PFAssertSafeMultiThreadedAccess off-queue). See #749.
+        Model.deleteCoreDataObjects(viewContext: viewContext, deletionScope: .expertisesOnly)
         #expect(Expertise.count(context: bgContext) == 0)
         #expect(LocalizedExpertise.count(context: bgContext) == 0)
         #expect(PhotographerExpertise.count(context: bgContext) == 0)
@@ -44,15 +58,17 @@ private let isBeingTested = true
     // Read abstract.level0.json.
     // Clears all CoreData expertises. Runs on background thread, adding bunch of extra complexity ;-(
     @Test("Parse abstractExpertise.level0.json") func abstractExpertiseLevel0Parse() async {
-        let bgContext = PersistenceController.shared.container.newBackgroundContext()
+        let bgContext = testPersistenceController.container.newBackgroundContext()
         bgContext.name = "AbstractExpertiseLevel0"
         bgContext.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
         bgContext.automaticallyMergesChangesFromParent = true
 
-        Model.deleteCoreDataObjects(viewContext: bgContext, deletionScope: .expertisesOnly)
-        #expect(Expertise.count(context: bgContext) == 0) // returns 3 instead of zero, why??
+        // Deletion must run on the main-queue viewContext: deleteCoreDataObjects is a @MainActor
+        // main-thread API (its bare save() would trip _PFAssertSafeMultiThreadedAccess off-queue). See #749.
+        Model.deleteCoreDataObjects(viewContext: viewContext, deletionScope: .expertisesOnly)
+        #expect(Expertise.count(context: bgContext) == 0)
         #expect(LocalizedExpertise.count(context: bgContext) == 0)
-        #expect(PhotographerExpertise.count(context: bgContext) == 0) // returns 3 instead of zero, why??
+        #expect(PhotographerExpertise.count(context: bgContext) == 0)
 
         bgContext.performAndWait {
             _ = Level0JsonReader(bgContext: bgContext, // read root.Level0.json file
@@ -69,12 +85,14 @@ private let isBeingTested = true
     // Read root.level0.json and check for parsing errors.
     // Clears all CoreData expertises. Runs on background thread, adding bunch of extra complexity ;-(
     @Test("Parse root.level0.json") func rootLevel0Parse() async {
-        let bgContext = PersistenceController.shared.container.newBackgroundContext()
+        let bgContext = testPersistenceController.container.newBackgroundContext()
         bgContext.name = "RootLevel0"
         bgContext.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
         bgContext.automaticallyMergesChangesFromParent = true
 
-        Model.deleteCoreDataObjects(viewContext: bgContext, deletionScope: .expertisesOnly)
+        // Deletion must run on the main-queue viewContext: deleteCoreDataObjects is a @MainActor
+        // main-thread API (its bare save() would trip _PFAssertSafeMultiThreadedAccess off-queue). See #749.
+        Model.deleteCoreDataObjects(viewContext: viewContext, deletionScope: .expertisesOnly)
 
         _ = Level0JsonReader(bgContext: bgContext, // read root.Level0.json file
                              fileName: "root",
@@ -86,12 +104,14 @@ private let isBeingTested = true
     // Read language.level0.json.
     // Clears all CoreData languages. Runs on background thread, adding bunch of extra complexity ;-(
     @Test("Parse language.level0.json") func languageLevel0Parse() async {
-        let bgContext = PersistenceController.shared.container.newBackgroundContext()
+        let bgContext = testPersistenceController.container.newBackgroundContext()
         bgContext.name = "LanguageLevel0"
         bgContext.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
         bgContext.automaticallyMergesChangesFromParent = true
 
-        Model.deleteCoreDataObjects(viewContext: bgContext, deletionScope: .expertisesOnly)
+        // Deletion must run on the main-queue viewContext: deleteCoreDataObjects is a @MainActor
+        // main-thread API (its bare save() would trip _PFAssertSafeMultiThreadedAccess off-queue). See #749.
+        Model.deleteCoreDataObjects(viewContext: viewContext, deletionScope: .expertisesOnly)
         #expect(Language.count(context: bgContext, isoCode: "UR") == 0)
         #expect(LocalizedRemark.count(context: bgContext) == 0)
         #expect(LocalizedExpertise.count(context: bgContext) == 0)
@@ -109,12 +129,14 @@ private let isBeingTested = true
     // Read language.level0.json.
     // Clears all CoreData languages. Runs on background thread, adding bunch of extra complexity ;-(
     @Test("Parse languages.level0.json") func languagesLevel0Parse() async {
-        let bgContext = PersistenceController.shared.container.newBackgroundContext()
+        let bgContext = testPersistenceController.container.newBackgroundContext()
         bgContext.name = "LanguagesLevel0"
         bgContext.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
         bgContext.automaticallyMergesChangesFromParent = true
 
-        Model.deleteCoreDataObjects(viewContext: bgContext, deletionScope: .expertisesOnly)
+        // Deletion must run on the main-queue viewContext: deleteCoreDataObjects is a @MainActor
+        // main-thread API (its bare save() would trip _PFAssertSafeMultiThreadedAccess off-queue). See #749.
+        Model.deleteCoreDataObjects(viewContext: viewContext, deletionScope: .expertisesOnly)
         #expect(Language.count(context: bgContext, isoCode: "UR") == 0)
         #expect(LocalizedRemark.count(context: bgContext) == 0)
         #expect(LocalizedExpertise.count(context: bgContext) == 0)

--- a/Photo Club Hub Data/Tests/Photo Club Hub DataTests/Level2JsonReaderTest.swift
+++ b/Photo Club Hub Data/Tests/Photo Club Hub DataTests/Level2JsonReaderTest.swift
@@ -11,25 +11,34 @@ import CoreData // for NSManagedObjectContext
 
 @MainActor @Suite("Tests the Level 2 JSON reader") struct Level2JsonReaderTests {
 
-    private let context: NSManagedObjectContext
+    private let testPersistenceController: PersistenceController
+    private let viewContext: NSManagedObjectContext
 
     init () {
-        context = PersistenceController.shared.container.viewContext
+        // Each test gets its own private in-memory store, so the app's concurrent background
+        // data-loading into PersistenceController.shared can't pollute the Expertise/PhotographerExpertise
+        // counts below. Swift Testing creates a fresh suite instance (and thus a fresh init) per test, so
+        // the store is effectively per-test — no deletion or cross-test isolation needed.
+        testPersistenceController = PersistenceController(inMemory: true) // inMemory is important for isolation
+        viewContext = testPersistenceController.container.viewContext
+        viewContext.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
+
+        // The empty store lacks several constant records the app seeds at launch; seed them here.
+        // Providers create .club organizations that reference OrganizationType, so both are needed.
+        // Must run on the main-queue viewContext (initConstants does a bare `save()`). See #749.
+        Language.initConstants(context: viewContext)
+        OrganizationType.initConstants(context: viewContext)
     }
 
     // Read TemplateMin.level2.json and check for parsing errors.
-    // Clears all CoreData expertises. Runs on background thread, adding bunch of extra complexity ;-(
     @Test("Parse TemplateMin.level2.json") func templateMinParse() async {
-        let bgContext = PersistenceController.shared.container.newBackgroundContext()
-        bgContext.name = "TemplateMin"
+        let bgContext = testPersistenceController.container.newBackgroundContext()
+        bgContext.name = "TemplateMinTest"
         bgContext.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
         bgContext.automaticallyMergesChangesFromParent = true
 
-        Model.deleteCoreDataObjects(viewContext: bgContext, deletionScope: .expertisesOnly)
-        #expect(Expertise.count(context: bgContext) == 0)
+        #expect(Expertise.count(context: bgContext) == 0) // clearing is handled via "inMemory: true"
 
-        // note that club TemplateMin may already be loaded
-        // note that TemplateMinMembersProvider runs asynchronously (via bgContext.perform {})
         let randomTownForTesting = String.random(length: 10)
 
         _ = TemplateMinMembersProvider(bgContext: bgContext,
@@ -37,7 +46,7 @@ import CoreData // for NSManagedObjectContext
                                        useOnlyInBundleFile: true,
                                        randomTownForTesting: randomTownForTesting)
 
-        let idPlus = OrganizationIdPlus(fullName: "Template Club with Minimal Data",
+        let idPlus = OrganizationIdPlus(fullName: "Template Club With Minimal Data",
                                         town: randomTownForTesting, // town to keep this separate from normal club data
                                         nickname: "TemplateMin")
 
@@ -48,7 +57,7 @@ import CoreData // for NSManagedObjectContext
                                     argumentArray: [ randomTownForTesting ] )
         let fetchRequest: NSFetchRequest<Organization> = Organization.fetchRequest()
         fetchRequest.predicate = predicate
-        let organizations: [Organization] = (try? context.fetch(fetchRequest)) ?? []
+        let organizations: [Organization] = (try? viewContext.fetch(fetchRequest)) ?? []
 
         #expect(Expertise.count(context: bgContext) == 0)
         #expect(PhotographerExpertise.count(context: bgContext) == 0)  // A club without PhotographerExpertises
@@ -64,18 +73,14 @@ import CoreData // for NSManagedObjectContext
     }
 
     // Read TemplateMax.level2.json and check for parsing errors
-    // Clears all CoreData expertises. Runs on background thread, adding bunch of extra complexity ;-(
     @Test("Parse TemplateMax.level2.json") func templateMaxParse() async {
-        let bgContext = PersistenceController.shared.container.newBackgroundContext()
-        bgContext.name = "TemplateMax"
+        let bgContext = testPersistenceController.container.newBackgroundContext()
+        bgContext.name = "TemplateMaxTest"
         bgContext.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
         bgContext.automaticallyMergesChangesFromParent = true
 
-        Model.deleteCoreDataObjects(viewContext: bgContext, deletionScope: .expertisesOnly)
         #expect(Expertise.count(context: bgContext) == 0)
 
-        // note that club TemplateMax may already be loaded
-        // note that TemplateMaxMembersProvider runs asynchronously (via bgContext.perform {})
         let randomTownForTesting = String.random(length: 10)
         _ = TemplateMaxMembersProvider(bgContext: bgContext,
                                        isBeingTested: true,
@@ -93,7 +98,7 @@ import CoreData // for NSManagedObjectContext
                                     argumentArray: [ randomTownForTesting ] )
         let fetchRequest: NSFetchRequest<Organization> = Organization.fetchRequest()
         fetchRequest.predicate = predicate
-        let organizations: [Organization] = (try? context.fetch(fetchRequest)) ?? []
+        let organizations: [Organization] = (try? viewContext.fetch(fetchRequest)) ?? []
 
         #expect(Expertise.count(context: bgContext) == 5)
         #expect(PhotographerExpertise.count(context: bgContext, expertiseID: "Landscape") == 1)
@@ -108,18 +113,17 @@ import CoreData // for NSManagedObjectContext
     }
 
     // Read fgDeGender.level2.json and check for parsing errors
-    // Clears all CoreData expertises. Runs on background thread, adding bunch of extra complexity ;-(
     @Test("Parse fgDeGender.level2.json") func fgDeGenderParse() async {
-        let bgContext = PersistenceController.shared.container.newBackgroundContext()
+        let bgContext = testPersistenceController.container.newBackgroundContext()
         bgContext.name = "fgDeGender"
         bgContext.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
         bgContext.automaticallyMergesChangesFromParent = true
 
-        Model.deleteCoreDataObjects(viewContext: bgContext, deletionScope: .expertisesOnly)
+        // Deletion must run on the main-queue viewContext: deleteCoreDataObjects is a @MainActor
+        // main-thread API (its bare save() would trip _PFAssertSafeMultiThreadedAccess off-queue). See #749.
+        Model.deleteCoreDataObjects(viewContext: viewContext, deletionScope: .expertisesOnly)
         #expect(Expertise.count(context: bgContext) == 0)
 
-        // note that club fgDeGender may already be loaded
-        // note that fgDeGenderMembersProvider runs asynchronously (via bgContext.perform {})
         let randomTownForTesting = String.random(length: 10)
         _ = FotogroepDeGenderMembersProvider(bgContext: bgContext, // The club has Expertises
                                              isBeingTested: true,
@@ -133,7 +137,7 @@ import CoreData // for NSManagedObjectContext
                                     argumentArray: [ randomTownForTesting ] )
         let fetchRequest: NSFetchRequest<Organization> = Organization.fetchRequest()
         fetchRequest.predicate = predicate
-        let organizations: [Organization] = (try? context.fetch(fetchRequest)) ?? []
+        let organizations: [Organization] = (try? viewContext.fetch(fetchRequest)) ?? []
 
         let idPlus = OrganizationIdPlus(fullName: "Fotogroep de Gender",
                                         town: randomTownForTesting, // town to distinguish this from normal club data
@@ -145,26 +149,26 @@ import CoreData // for NSManagedObjectContext
             #expect(organizations[0].fullName == idPlus.fullName)
             #expect(organizations[0].town == idPlus.town)
             #expect(organizations[0].nickName == idPlus.nickname)
-            #expect(organizations[0].fotobondClubNumber?.id == 1620)
+            #expect(organizations[0].fotobondClubNumber?.id == nil) // club in randomTown → no fotobondNumber
         }
 
         #expect(Expertise.count(context: bgContext) == 21)
-        #expect(PhotographerExpertise.count(context: bgContext, expertiseID: "Minimal") == 3)
-        #expect(PhotographerExpertise.count(context: bgContext) == 14)
+        #expect(PhotographerExpertise.count(context: bgContext, expertiseID: "Minimal") == 2)
+        #expect(PhotographerExpertise.count(context: bgContext) == 50)
     }
 
     // Read and check for expertise merging
-    // Clears all CoreData expertises. Runs on background thread, adding bunch of extra complexity ;-(
     @Test("Load 2 clubs with expertise data for same photographer") func fgWaalreFgDeGender() async {
-        let bgContext = PersistenceController.shared.container.newBackgroundContext()
+        let bgContext = testPersistenceController.container.newBackgroundContext()
         bgContext.name = "fgDeGender"
         bgContext.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
         bgContext.automaticallyMergesChangesFromParent = true
 
-        Model.deleteCoreDataObjects(viewContext: bgContext, deletionScope: .expertisesOnly) // remove Expertises
+        // Deletion must run on the main-queue viewContext: deleteCoreDataObjects is a @MainActor
+        // main-thread API (its bare save() would trip _PFAssertSafeMultiThreadedAccess off-queue). See #749.
+        Model.deleteCoreDataObjects(viewContext: viewContext, deletionScope: .expertisesOnly) // remove Expertises
         #expect(Expertise.count(context: bgContext) == 0)
 
-        // note that club fgDeGender may already be loaded
         // note that fgDeGenderMembersProvider runs asynchronously (via bgContext.perform {})
         let randomTownForTestingG = String.random(length: 10)
         _ = FotogroepDeGenderMembersProvider(bgContext: bgContext,
@@ -172,7 +176,7 @@ import CoreData // for NSManagedObjectContext
                                              useOnlyInBundleFile: true,
                                              randomTownForTesting: randomTownForTestingG)
         #expect(Expertise.count(context: bgContext) == 21)
-        #expect(PhotographerExpertise.count(context: bgContext) == 14)
+        #expect(PhotographerExpertise.count(context: bgContext) == 50)
 
         let randomTownForTestingW = String.random(length: 10)
         _ = FotogroepWaalreMembersProvider(bgContext: bgContext,
@@ -180,8 +184,8 @@ import CoreData // for NSManagedObjectContext
                                            useOnlyInBundleFile: true,
                                            randomTownForTesting: randomTownForTestingW)
 
-        #expect(Expertise.count(context: bgContext) == 21)
-        #expect(PhotographerExpertise.count(context: bgContext) == 42)
+        #expect(Expertise.count(context: bgContext) == 22)
+        #expect(PhotographerExpertise.count(context: bgContext) == 50 + 44 - 2) // DeGender + Waalre - overlap
     }
 
 }

--- a/Photo Club Hub Data/Tests/Photo Club Hub DataTests/LocalizedExpertiseTest.swift
+++ b/Photo Club Hub Data/Tests/Photo Club Hub DataTests/LocalizedExpertiseTest.swift
@@ -52,7 +52,7 @@ import CoreData // for NSManagedObjectContext
                                                                       localizedUsage: localizedUsage)
         LocalizedExpertise.save(context: context) // probably not needed, but sloppy not to commit this change
 
-        #expect(localizedExpertise.language.isoCode == "EN")
+        #expect(localizedExpertise.language.isoCode == "en")
         #expect(localizedExpertise.language.nameEN == "English")
     }
 


### PR DESCRIPTION
Closes #233

## Problem
All `Level0JsonReaderTests` crashed with a `fatalError` (via `ifDebugFatalError`) instead of running their assertions, and the Level 2 suite had latent test-isolation issues.

## Changes

### Resource bundle resolution (`FetchAndProcessFile.swift`)
Tests run under the standalone `xctest` tool, so `Bundle.main` is that tool and the original search paths never reached the test target's resources (which live in the loaded `.xctest` bundle's nested `<Package>_<Target>.bundle`). `urlForBundledResource` now also scans the loaded `.xctest` bundle. The scan is deliberately scoped to that bundle rather than all of `Bundle.allBundles`, which would enumerate frameworks inside Xcode.app and trip the macOS privacy (TCC) "access data from other apps" prompt.

### Per-test isolation (`Level0JsonReaderTest.swift`, `Level2JsonReaderTest.swift`)
Ported the improved pattern from the companion Photo Club Hub iOS repo: each test uses its own `PersistenceController(inMemory: true)` and seeds constants in `init()`; deletion/fetches run on the main-queue `viewContext`. Several Level 2 assertions were corrected — under proper isolation the real data differs from the old values (which only passed because the shared store leaked pre-existing records), and the corrected values match the iOS repo.

## Verification
All 9 Level 0 + Level 2 tests pass, individually and together.